### PR TITLE
Govcon-sandbox - 01-core: Remove breakpoint instructions

### DIFF
--- a/src/_styles/_uswds-theme.scss
+++ b/src/_styles/_uswds-theme.scss
@@ -7,13 +7,6 @@
 // System colors documentation.
 // https://designsystem.digital.gov/colors/system
 
-// !
-// ! Exercises:
-// !
-// ! 1. Enable the `tablet-lg` breakpoint.
-// !    https://designsystem.digital.gov/utilities/layout-grid/#variables-2
-// !
-
 @use "uswds-core" with (
   // Active development settings.
   $theme-show-notifications: false,


### PR DESCRIPTION
# Summary

Removes breakpoint instruction from `_uswds-theme.scss`

This instruction is meant for `02-prototyping`.