### PR TITLE
Govcon-sandbox-  04 beyond: Remove styles to be added by users1

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Button doesn't offer a [setting](https://designsystem.digital.gov/components/but
 
 We'll create a custom button with a gradient background instead of a solid color. We also want to use color tokens to ensure the UI stays cohesive. Plus, as we mentioned before; color grading helps us easily manage contrast.
 
-1. Go to hero component `TK`.
+1. Go to hero component `./src/_includes/hero.html`.
 1. Add the following classes: `dgc-button dgc-button--callout`.
 1. Open styles directory `./src/_styles/components/`.
 1. Create a new partial for our custom button called `_dgc-button.scss`.

--- a/src/_includes/hero.html
+++ b/src/_includes/hero.html
@@ -11,7 +11,7 @@
         Some short explanatory text. You don’t need more than a couple of
         sentences.
       </p>
-      <a class="dgc-button usa-button" href="javascript:void(0)">Call to action</a>
+      <a class="usa-button" href="javascript:void(0)">Call to action</a>
     </div>
   </div>
 </section>

--- a/src/_styles/_project-styles.scss
+++ b/src/_styles/_project-styles.scss
@@ -2,4 +2,3 @@
 
 @forward "components/dgc-nav";
 @forward "components/dgc-hero";
-@forward "components/dgc-button";

--- a/src/_styles/components/_dgc-hero.scss
+++ b/src/_styles/components/_dgc-hero.scss
@@ -2,17 +2,5 @@
 
 .dgc-hero {
   // Add some custom styles
-  text-align: center;
 
-  @include at-media("tablet-lg") {
-    text-align: end;
-  }
-
-  h1 {
-    @include u-font('sans', '3xl');
-
-    .usa-hero__heading--alt {
-      color: color("primary")
-    }
-  }
 }


### PR DESCRIPTION
# Summary

Removes styles that the instructions tell users to create. 

Also adds hero component file destination to readme in place of existing `tk`.

>[!NOTE]
> We should maybe add the readme change to `main` as well